### PR TITLE
add necessary IAM roles to default GCE svc acct

### DIFF
--- a/08-cloud-deploy-setup.sh
+++ b/08-cloud-deploy-setup.sh
@@ -13,6 +13,12 @@ function delete_old_pipelines() {
 }
 # Add your code here:
 
+# Add roles to default compute engine service account
+PROJECT_NUMBER=$(gcloud projects list --filter="$PROJECT_ID" --format="value(PROJECT_NUMBER)")
+GCE_SVC_ACCT="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+gcloud projects add-iam-policy-binding --member="serviceAccount:${GCE_SVC_ACCT}" --role "roles/storage.objectCreator" "$PROJECT_ID"
+gcloud projects add-iam-policy-binding --member="serviceAccount:${GCE_SVC_ACCT}" --role "roles/container.developer" "$PROJECT_ID"
+
 CLOUD_DEPLOY_TEMPLATING_VER="1-2"
 
 cat clouddeploy.template.yaml |


### PR DESCRIPTION
### Problem
Following the docs linearly, I get the following errors when running `./08-cloud-deploy-setup.sh`.

#### Error 1
```
2022-07-11T16:26:18.246728928Z Copying file:///workspace/rendered/skaffold.yaml [Content-Type=application/octet-stream]...
Info
2022-07-11T16:26:18.427942055Z AccessDeniedException: 403 136027582638-compute@developer.gserviceaccount.com does not have storage.objects.create access to the Google Cloud Storage object.
Info
2022-07-11T16:26:18.453183206Z CommandException: 1 file/object could not be transferred.
Info
2022-07-11T16:26:18.981071868Z ERROR
Info
2022-07-11T16:26:18.981105981Z ERROR: could not upload /workspace/rendered/skaffold.yaml to gs://us-central1.deploy-artifacts.plat-path-00.appspot.com/app01-20220711-1625-v2-3-fa8aa86c7c3244e3b050e9c030241a20/canary/; err = gsutil exited with non-zero status: 1
Info
2022-07-11T16:26:19.142109184Z / [0/1 files][ 0.0 B/ 543.0 B] 0% Done
```
#### Error 1 Fix
Giving `136027582638-compute@developer.gserviceaccount.com` Storage Object Creator role fixes the issue.

#### Error 2
```
2022-07-11T18:30:38.047032735Z Fetching cluster endpoint and auth data.
Info
2022-07-11T18:30:38.131125194Z ERROR: (gcloud.container.clusters.get-credentials) ResponseError: code=403, message=Required "container.clusters.get" permission(s) for "projects/plat-path-00/locations/us-central1/clusters/cicd-dev".
Info
2022-07-11T18:30:38.747207944Z ERROR
Info
2022-07-11T18:30:38.747248722Z ERROR: build step 0 "gcr.io/k8s-skaffold/skaffold:v1.37.2-lts" failed: step exited with non-zero status: 1
```

#### Error 2 Fix
Giving `136027582638-compute@developer.gserviceaccount.com` Kubernetes Engine Developer role fixes the issue.
