### PR TITLE
add kustomize to render k8s manifests for solution 2

### DIFF
--- a/apps/app01/k8s/overlays/canary-sol2/kustomization.yaml
+++ b/apps/app01/k8s/overlays/canary-sol2/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../canary
+  - service.yaml
+components:
+  - ../../../../../components/common/canary

--- a/apps/app01/k8s/overlays/canary-sol2/service.yaml
+++ b/apps/app01/k8s/overlays/canary-sol2/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app01-sol2-svc-canary
+  annotations:
+    networking.gke.io/max-rate-per-endpoint: "10"
+    cloud.google.com/neg: '{"exposed_ports": {"8080":{"name": "app01-sol2-svc-canary-neg"}}}'
+spec:
+  selector:
+    app: app01-kupython
+    ricc-env: canary
+  ports:
+  - port: 8080
+    targetPort: 8080

--- a/apps/app01/k8s/overlays/production-sol2/kustomization.yaml
+++ b/apps/app01/k8s/overlays/production-sol2/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../production
+  - service.yaml
+components:
+  - ../../../../../components/common/prod

--- a/apps/app01/k8s/overlays/production-sol2/service.yaml
+++ b/apps/app01/k8s/overlays/production-sol2/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app01-sol2-svc-prod
+  annotations:
+    networking.gke.io/max-rate-per-endpoint: "10"
+    cloud.google.com/neg: '{"exposed_ports": {"8080":{"name": "app01-sol2-svc-prod-neg"}}}'
+spec:
+  selector:
+    app: app01-kupython
+    ricc-env: prod
+  ports:
+  - port: 8080
+    targetPort: 8080

--- a/apps/app01/skaffold.yaml
+++ b/apps/app01/skaffold.yaml
@@ -49,6 +49,14 @@ profiles:
     deploy:
       kustomize: # uses kustomize
         paths: [./k8s/overlays/production]
+  - name: canary-sol2
+    deploy:
+      kustomize:
+        paths: [./k8s/overlays/canary-sol2]
+  - name: production-sol2
+    deploy:
+      kustomize:
+        paths: [./k8s/overlays/production-sol2]
 
 # TODO skaffold profile for solutions. then use with skaffold render or CD release CLI.
 #   - name: canary-solution1

--- a/apps/app02/k8s/overlays/canary-sol2/kustomization.yaml
+++ b/apps/app02/k8s/overlays/canary-sol2/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../canary
+  - service.yaml
+components:
+  - ../../../../../components/common/canary

--- a/apps/app02/k8s/overlays/canary-sol2/service.yaml
+++ b/apps/app02/k8s/overlays/canary-sol2/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app02-sol2-svc-canary
+  annotations:
+    networking.gke.io/max-rate-per-endpoint: "10"
+    cloud.google.com/neg: '{"exposed_ports": {"8080":{"name": "app02-sol2-svc-canary-neg"}}}'
+spec:
+  selector:
+    app: app02-kuruby
+    ricc-env: canary
+  ports:
+  - port: 8080
+    targetPort: 8080

--- a/apps/app02/k8s/overlays/production-sol2/kustomization.yaml
+++ b/apps/app02/k8s/overlays/production-sol2/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../production
+  - service.yaml
+components:
+  - ../../../../../components/common/prod

--- a/apps/app02/k8s/overlays/production-sol2/service.yaml
+++ b/apps/app02/k8s/overlays/production-sol2/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app02-sol2-svc-prod
+  annotations:
+    networking.gke.io/max-rate-per-endpoint: "10"
+    cloud.google.com/neg: '{"exposed_ports": {"8080":{"name": "app02-sol2-svc-prod-neg"}}}'
+spec:
+  selector:
+    app: app02-kuruby
+    ricc-env: prod
+  ports:
+  - port: 8080
+    targetPort: 8080

--- a/apps/app02/skaffold.yaml
+++ b/apps/app02/skaffold.yaml
@@ -36,3 +36,11 @@ profiles:
     deploy:
       kustomize:
         paths: ["k8s/overlays/production"]
+  - name: canary-sol2
+    deploy:
+      kustomize:
+        paths: [./k8s/overlays/canary-sol2]
+  - name: production-sol2
+    deploy:
+      kustomize:
+        paths: [./k8s/overlays/production-sol2]


### PR DESCRIPTION
**THIS IS NOT TESTED!!! PLEASE DO NOT MERGE!!!**

Short example showcasing how to use kustomize to render k8s manifests for solution 2 instead of using templating.